### PR TITLE
Fix cursor for cases where script's iter returns false.

### DIFF
--- a/internal/server/scanner.go
+++ b/internal/server/scanner.go
@@ -45,7 +45,7 @@ type scanner struct {
 	nofields       bool
 	cursor         uint64
 	limit          uint64
-	hitLimit       bool
+	earlyStop      bool
 	once           bool
 	count          uint64
 	precision      uint64
@@ -137,7 +137,7 @@ func (sc *scanner) writeFoot() {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
 	cursor := sc.numberIters
-	if !sc.hitLimit {
+	if !sc.earlyStop {
 		cursor = 0
 	}
 	sc.collector.Complete(sc, cursor)
@@ -319,13 +319,15 @@ func (sc *scanner) writeObject(opts ScanObjectParams) bool {
 	if opts.clip != nil {
 		opts.o = clip.Clip(opts.o, opts.clip)
 	}
-	keepGoing = sc.collector.ProcessItem(sc, opts) && keepGoing
+	keepProcessing := sc.collector.ProcessItem(sc, opts)
 	sc.numberItems++
-	if sc.numberItems == sc.limit {
-		sc.hitLimit = true
+	// Regular stop is when we exhausted all objects.
+	// Early stop is when we either hit the limit or ProcessItem() returned false (scripts)
+	if sc.numberItems == sc.limit || !keepProcessing {
+		sc.earlyStop = true
 		return false
 	}
-	return keepGoing
+	return keepProcessing && keepGoing
 }
 
 type scanCollector interface {


### PR DESCRIPTION
Before the new lua iterator, there was a simple logic in `writeFoot()`: if we didn't hit the specified limit then we must have exhausted the search, so set cursor to 0.

Now that the lua callback can return `false` to quit early, we need to fix this logic.

I tweaked the tests to make sure we're correct in all three cases:
* exhausting the scan,
* hitting the limit, and
* getting `false` returned from the callback.